### PR TITLE
Pathfinding behavior update

### DIFF
--- a/mods/CarrierCommander/config/CarrierCommanderConfig.lua
+++ b/mods/CarrierCommander/config/CarrierCommanderConfig.lua
@@ -1,6 +1,6 @@
 local Config = {}
 
-Config.Author = "Nexus, Dirtyredz, Hammelpilaw, Maxx4u, Laserzwei"
+Config.Author = "Nexus, Dirtyredz, Hammelpilaw, Maxx4u, Laserzwei, Cwhizard"
 Config.ModName = "CarrierCommander"
 Config.version = {
     major=0, minor=10, patch = 0,

--- a/mods/CarrierCommander/scripts/entity/ai/aggressiveCommand.lua
+++ b/mods/CarrierCommander/scripts/entity/ai/aggressiveCommand.lua
@@ -63,18 +63,25 @@ function aggressiveCommand.initConfigUI(scrollframe, pos, size)
     --attack Civils
     local checkBox = scrollframe:createCheckBox(Rect(pos+vec2(0,5),pos+vec2(size.x-35, 25)), "Attack Civils", "onCheckBoxChecked")
     cc.l.uiElementToSettingMap[checkBox.index] = aggressiveCommand.prefix.."spareCivilsSetting"
-    checkBox.tooltip = "Determines wether enemy civil ships will be attacked (checkded), or not (unchecked)"
+    checkBox.tooltip = "Determines wether enemy civil ships will be attacked (checked), or not (unchecked)"
     checkBox.captionLeft = false
     checkBox.fontSize = 14
     pos = pos + vec2(0,35)
 
     local checkBox = scrollframe:createCheckBox(Rect(pos+vec2(0,5),pos+vec2(size.x-35, 25)), "Attack Stations", "onCheckBoxChecked")
     cc.l.uiElementToSettingMap[checkBox.index] = aggressiveCommand.prefix.."attackStations"
-    checkBox.tooltip = "Determines wether enemy stations will be attacked (checkded), or not (unchecked)"
+    checkBox.tooltip = "Determines wether enemy stations will be attacked (checked), or not (unchecked)"
     checkBox.captionLeft = false
     checkBox.fontSize = 14
     pos = pos + vec2(0,35)
 
+    local checkBox = scrollframe:createCheckBox(Rect(pos+vec2(0,5),pos+vec2(size.x-35, 25)), "Aggressive Targetting", "onCheckBoxChecked")
+    cc.l.uiElementToSettingMap[checkBox.index] = aggressiveCommand.prefix.."attackNearest"
+    checkBox.tooltip = "Attack ship closest to squad (checked), or closest to ship (unchecked)"
+    checkBox.captionLeft = false
+    checkBox.fontSize = 14
+    pos = pos + vec2(0,35)
+    
     return pos
 end
 

--- a/mods/CarrierCommander/scripts/entity/ai/mineCommand.lua
+++ b/mods/CarrierCommander/scripts/entity/ai/mineCommand.lua
@@ -124,21 +124,25 @@ function mineCommand.findMinableAsteroid()
     local ship = Entity()
     local sector = Sector()
     local oldAstroNum
-
+    local sourceXYZ
+    
     if valid(mineCommand.minableAsteroid) then -- because even after the "asteroiddestroyed" event fired it still is part of sector:getEntitiesByType(EntityType.Asteroid) >,<
         oldAstroNum = mineCommand.minableAsteroid.index.number
+        sourceXYZ = mineCommand.minableAsteroid.translationf
         mineCommand.unregisterTarget()
+        else
+        sourceXYZ = ship.translationf
     end
 
     mineCommand.minableAsteroid = nil
 
     local asteroids = {sector:getEntitiesByType(EntityType.Asteroid)}
     local nearest = math.huge
-    --Go after closest asteroids first
+    --Go after the asteroid closest to the one just finished (Nearest Neighbor)
     for _, a in pairs(asteroids) do
         local resources = a:getMineableResources()
         if ((resources ~= nil and resources > 0) or cc.settings["mineAllSetting"]) and a.index.number ~= oldAstroNum then
-            local dist = distance2(a.translationf, ship.translationf)
+            local dist = distance2(a.translationf, sourceXYZ)
             if dist < nearest then
                 nearest = dist
                 mineCommand.minableAsteroid = a

--- a/mods/CarrierCommander/scripts/entity/ai/salvageCommand.lua
+++ b/mods/CarrierCommander/scripts/entity/ai/salvageCommand.lua
@@ -132,10 +132,14 @@ function salvageCommand.findWreckage()
     local ship = Entity()
     local sector = Sector()
     local oldWreckNum
+    local sourceXYZ
 
     if valid(salvageCommand.salvagableWreck) then -- because even after the "wreckagedestroyed" event fired it still is part of sector:getEntitiesByType(EntityType.Wreckage) >,<
         oldWreckNum = salvageCommand.salvagableWreck.index.number
+	sourceXYZ = salvageCommand.salvagableWreck.translationf
         salvageCommand.unregisterTarget()
+	else
+	sourceXYZ = ship.translationf
     end
 
     salvageCommand.salvagableWreck = nil
@@ -147,7 +151,7 @@ function salvageCommand.findWreckage()
 		w:waitUntilAsyncWorkFinished()
         local resources = w:getMineableResources()
         if resources ~= nil and resources > 5 and oldWreckNum ~= w.index.number then
-            local dist = distance2(w.translationf, ship.translationf)
+            local dist = distance2(w.translationf, sourceXYZ)
             if dist < nearest then
                 nearest = dist
                 salvageCommand.salvagableWreck = w


### PR DESCRIPTION
I am currently using the steam name The Great White King, so this is my code, which I posted to the forum last night.  I have additionally made the change to the salvaging code to use the same algorithm.  Since I basically see salvaging as another form of mining.

The changes add no new features, they merely improve the pathfinding quite a lot.  I haven't made actual measurements, but anecdotally the mining at least seems to be about 4 times faster due to avoiding the zig zag condition.

There is one issue, in that sometimes the script will not target the nearest asteroid to the ship when starting.  This has only happened once, and the asteroid was less than 1Km from the ship spawn point and was targeted properly down the line.  I have no earthly idea why this happened and it has not repeated since.  I suspect this would have happened with the old code as well since on script start, it basically uses the old method to target the first asteroid.